### PR TITLE
docs: Add Github actions build status and PyPI version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Documentation Status](https://readthedocs.org/projects/nada-dsl/badge/?version=latest)](https://nada-dsl.readthedocs.io/en/latest/?badge=latest)
+![Build Status](https://github.com/NillionNetwork/nada-dsl/actions/workflows/build.yml/badge.svg)
+![PyPI - Version](https://img.shields.io/pypi/v/:packageName)
 
 # nada-dsl
 


### PR DESCRIPTION
Adds two badges to the README, one for the build status and another one that tells the current PyPI release.
