### PR TITLE
feat: Add support for Python builtin sum

### DIFF
--- a/nada_dsl/nada_types/scalar_types.py
+++ b/nada_dsl/nada_types/scalar_types.py
@@ -161,6 +161,16 @@ class NumericType(ScalarType):
             "GreaterOrEqualThan", ">=", self, other, lambda lhs, rhs: lhs >= rhs
         )
 
+    def __radd__(self, other):
+        """This adds support for builtin `sum` operation for numeric types."""
+        if isinstance(other, int):
+            other_type = new_scalar_type(mode=Mode.CONSTANT, base_type=self.base_type)(
+                other
+            )
+            return self.__add__(other_type)
+
+        return self.__add__(other)
+
 
 def binary_arithmetic_operation(
     operation, operator, left: ScalarType, right: ScalarType, f

--- a/test-programs/sum_integers.py
+++ b/test-programs/sum_integers.py
@@ -1,0 +1,11 @@
+from nada_dsl import *
+
+
+def nada_main():
+    party1 = Party(name="Party1")
+    my_int1 = SecretInteger(Input(name="my_int1", party=party1))
+    my_int2 = SecretInteger(Input(name="my_int2", party=party1))
+
+    total = sum([my_int1, my_int2], -2)
+
+    return [Output(total, "my_output", party1)]


### PR DESCRIPTION
## Changes

Adds support for Python builtin `sum` operation by allowing integers in `__radd__` for numeric values. 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Backwards compatability analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
