### PR TITLE
fix: Do not compile nada functions that use literals

### DIFF
--- a/nada_dsl/compile_test.py
+++ b/nada_dsl/compile_test.py
@@ -9,6 +9,7 @@ import pytest
 from nada_dsl.ast_util import AST_OPERATIONS
 from nada_dsl.compile import compile_script, compile_string
 from nada_dsl.compiler_frontend import FUNCTIONS, INPUTS, PARTIES
+from nada_dsl.errors import NotAllowedException
 
 
 @pytest.fixture(autouse=True)
@@ -123,3 +124,8 @@ def nada_main():
 
     with pytest.raises(NameError):
         compile_string(encoded_program_str)
+
+
+def test_compile_nada_fn_literals():
+    with pytest.raises(NotAllowedException):
+        mir_str = compile_script(f"{get_test_programs_folder()}/nada_fn_literal.py").mir

--- a/nada_dsl/nada_types/scalar_types.py
+++ b/nada_dsl/nada_types/scalar_types.py
@@ -72,6 +72,8 @@ def register_scalar_type(mode: Mode, base_type: BaseType):
 
     def decorator(scalar_type: ScalarType):
         SCALAR_TYPES[(mode, base_type)] = scalar_type
+        scalar_type.mode = mode
+        scalar_type.base_type = base_type
         return scalar_type
 
     return decorator
@@ -308,7 +310,6 @@ def binary_logical_operation(
     return SecretBoolean(inner=operation)
 
 
-@dataclass
 @register_scalar_type(Mode.CONSTANT, BaseType.INTEGER)
 class Integer(NumericType):
     """The Nada Integer type.

--- a/test-programs/nada_fn_literal.py
+++ b/test-programs/nada_fn_literal.py
@@ -1,0 +1,12 @@
+from nada_dsl import *
+
+
+def nada_main():
+    party1 = Party(name="Party1")
+
+    @nada_fn
+    def add(a: Integer, b: Integer) -> Integer:
+        return a + b
+
+    new_int = add(Integer(2), Integer(-5))
+    return [Output(new_int, "my_output", party1)]


### PR DESCRIPTION
Fixes https://github.com/NillionNetwork/nada-lang/issues/13

There is an edge case where users define nada functions that act over literals. The compiler wasn't able to compile it appropriately because the code doesn't know how to handle literal returns of functions. 

Functions having literal arguments or return types cannot be allowed because the compiler automatically consolidates operations using literals. An appropriate error is thrown now. 

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Backwards compatability analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
