### PR TITLE
feat: Add deterministic operation and function identifiers

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -430,7 +430,9 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         use-implicit-booleaness-not-comparison-to-string,
-        use-implicit-booleaness-not-comparison-to-zero,W0223,W0718,R0903,R0913,R0801,R0401,W0231,R0917
+        use-implicit-booleaness-not-comparison-to-zero,
+        too-many-positional-arguments,
+        W0223,W0718,R0903,R0913,R0801,R0401,W0231,W0603
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/nada_dsl/ast_util.py
+++ b/nada_dsl/ast_util.py
@@ -8,6 +8,23 @@ from sortedcontainers import SortedDict
 from nada_dsl.nada_types import NadaTypeRepr, Party
 from nada_dsl.source_ref import SourceRef
 
+OPERATION_ID_COUNTER = 0
+FUNCTION_ID_COUNTER = 0
+
+
+def next_operation_id() -> int:
+    """Returns the next value of the operation id counter."""
+    global OPERATION_ID_COUNTER
+    OPERATION_ID_COUNTER += 1
+    return OPERATION_ID_COUNTER
+
+
+def next_function_id() -> int:
+    """Returns the next value of the function id counter."""
+    global FUNCTION_ID_COUNTER
+    FUNCTION_ID_COUNTER += 1
+    return FUNCTION_ID_COUNTER
+
 
 @dataclass
 class ASTOperation(ABC):

--- a/nada_dsl/future/operations.py
+++ b/nada_dsl/future/operations.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 
 from nada_dsl import SourceRef
-from nada_dsl.ast_util import AST_OPERATIONS, CastASTOperation
+from nada_dsl.ast_util import AST_OPERATIONS, CastASTOperation, next_operation_id
 from nada_dsl.nada_types import AllTypes, AllTypesType
 
 
@@ -16,7 +16,7 @@ class Cast:
     source_ref: SourceRef
 
     def __init__(self, target: AllTypes, to: AllTypes, source_ref: SourceRef):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.target = target
         self.to = to
         self.source_ref = source_ref

--- a/nada_dsl/nada_types/collections.py
+++ b/nada_dsl/nada_types/collections.py
@@ -102,7 +102,7 @@ class Map(Generic[T, R]):
         fn: NadaFunction[T, R],
         source_ref: SourceRef,
     ):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.inner = inner
         self.fn = fn
         self.source_ref = source_ref
@@ -134,7 +134,7 @@ class Reduce(Generic[T, R]):
         initial: R,
         source_ref: SourceRef,
     ):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.inner = inner
         self.fn = fn
         self.initial = initial
@@ -213,7 +213,7 @@ class Zip:
     """The Zip operation."""
 
     def __init__(self, left: AllTypes, right: AllTypes, source_ref: SourceRef):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.left = left
         self.right = right
         self.source_ref = source_ref
@@ -234,7 +234,7 @@ class Unzip:
     """The Unzip operation."""
 
     def __init__(self, inner: AllTypes, source_ref: SourceRef):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.inner = inner
         self.source_ref = source_ref
 
@@ -253,7 +253,7 @@ class InnerProduct:
     """Inner product of two arrays."""
 
     def __init__(self, left: AllTypes, right: AllTypes, source_ref: SourceRef):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.left = left
         self.right = right
         self.source_ref = source_ref
@@ -498,7 +498,7 @@ class TupleNew(Generic[T, U]):
     def __init__(
         self, inner_type: NadaType, inner: typing.Tuple[T, U], source_ref: SourceRef
     ):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.inner = inner
         self.source_ref = source_ref
         self.inner_type = inner_type
@@ -536,7 +536,7 @@ class ArrayNew(Generic[T]):
     source_ref: SourceRef
 
     def __init__(self, inner_type: NadaType, inner: List[T], source_ref: SourceRef):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.inner = inner
         self.source_ref = source_ref
         self.inner_type = inner_type

--- a/nada_dsl/nada_types/function.py
+++ b/nada_dsl/nada_types/function.py
@@ -13,6 +13,8 @@ from nada_dsl.ast_util import (
     NadaFunctionASTOperation,
     NadaFunctionArgASTOperation,
     NadaFunctionCallASTOperation,
+    next_function_id,
+    next_operation_id,
 )
 from nada_dsl.nada_types.generics import T, R
 from nada_dsl.nada_types import NadaType
@@ -28,7 +30,7 @@ class NadaFunctionArg(Generic[T]):
     source_ref: SourceRef
 
     def __init__(self, function_id: int, name: str, arg_type: T, source_ref: SourceRef):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.function_id = function_id
         self.name = name
         self.type = arg_type
@@ -104,7 +106,7 @@ class NadaFunctionCall(Generic[R]):
     source_ref: SourceRef
 
     def __init__(self, nada_function, args, source_ref):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.args = args
         self.fn = nada_function
         self.source_ref = source_ref
@@ -146,12 +148,13 @@ def nada_fn(fn, args_ty=None, return_ty=None) -> NadaFunction[T, R]:
 
     args = inspect.getfullargspec(fn)
     nada_args = []
+    function_id = next_function_id()
     for arg in args.args:
         arg_type = args_ty[arg] if args_ty else args.annotations[arg]
         arg_type = inner_type(arg_type)
         # We'll get the function source ref for now
         nada_arg = NadaFunctionArg(
-            function_id=id(fn),
+            function_id,
             name=arg,
             arg_type=arg_type,
             source_ref=SourceRef.back_frame(),
@@ -169,7 +172,7 @@ def nada_fn(fn, args_ty=None, return_ty=None) -> NadaFunction[T, R]:
 
     return_type = return_ty if return_ty else args.annotations["return"]
     return NadaFunction(
-        function_id=id(fn),
+        function_id,
         function=fn,
         args=nada_args,
         inner=inner,

--- a/nada_dsl/operations.py
+++ b/nada_dsl/operations.py
@@ -10,6 +10,7 @@ from nada_dsl.ast_util import (
     IfElseASTOperation,
     RandomASTOperation,
     UnaryASTOperation,
+    next_operation_id,
 )
 from nada_dsl.nada_types import AllTypes
 
@@ -18,7 +19,7 @@ class BinaryOperation:
     """Superclass of all the binary operations."""
 
     def __init__(self, left: AllTypes, right: AllTypes, source_ref: SourceRef):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.left = left
         self.right = right
         self.source_ref = source_ref
@@ -39,7 +40,7 @@ class UnaryOperation:
     """Superclass of all the unary operations."""
 
     def __init__(self, inner: AllTypes, source_ref: SourceRef):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.inner = inner
         self.source_ref = source_ref
 
@@ -132,7 +133,7 @@ class Random:
     source_ref: SourceRef
 
     def __init__(self, source_ref):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.source_ref = source_ref
 
     def store_in_ast(self, ty):
@@ -156,7 +157,7 @@ class IfElse:
     def __init__(
         self, this: AllTypes, arg_0: AllTypes, arg_1: AllTypes, source_ref: SourceRef
     ):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.this = this
         self.arg_0 = arg_0
         self.arg_1 = arg_1

--- a/nada_dsl/program_io.py
+++ b/nada_dsl/program_io.py
@@ -7,7 +7,12 @@ Define the types used for inputs and outputs in Nada programs.
 from dataclasses import dataclass
 from typing import Any
 
-from nada_dsl.ast_util import AST_OPERATIONS, InputASTOperation, LiteralASTOperation
+from nada_dsl.ast_util import (
+    AST_OPERATIONS,
+    InputASTOperation,
+    LiteralASTOperation,
+    next_operation_id,
+)
 from nada_dsl.errors import InvalidTypeError
 from nada_dsl.nada_types import AllTypes, Party
 from nada_dsl.nada_types import NadaType
@@ -30,7 +35,7 @@ class Input(NadaType):
     source_ref: SourceRef
 
     def __init__(self, name, party, doc=""):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.name = name
         self.party = party
         self.doc = doc
@@ -62,7 +67,7 @@ class Literal(NadaType):
     source_ref: SourceRef
 
     def __init__(self, value, source_ref):
-        self.id = id(self)
+        self.id = next_operation_id()
         self.value = value
         self.source_ref = source_ref
         self.inner = None


### PR DESCRIPTION
Fixes https://github.com/NillionNetwork/nada-lang/issues/17. 
This pull request replaces the operation and function identifier generation. Instead of using the Python builtin `id`, it uses an incremental counter. 

This leads to reduce size of the compiled program. It also has the benefit of making the compiled program deterministic, that is, a program always has the same corresponding compiled representation. This property has been tested extensively with all the nada examples available in Nada By Example.