### PR TITLE
chore: run validation tests from Nillion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
+# This workflow builds and tests the project.
+# It runs for every pull request.
+# For testing currently uses the tests in Nillion repo.
 name: Build
 
 on:
@@ -33,3 +33,32 @@ jobs:
       - name: Test with pytest
         run: |
           pytest
+  # Test that the compiled programs are compatible the Nillion backend.
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Checkout tools repo
+        uses: actions/checkout@v4
+        with:
+          repository: NillionNetwork/nillion
+          path: nillion
+          token: ${{ secrets.NILLION_TOKEN }}
+      - name: Replace nillion's nada_dsl with this version
+        uses: actions/checkout@v4
+        with:
+          path: nillion/nada-lang/nada_dsl
+      - name: Check that test-programs compile
+        run: |
+          pip install -U virtualenv
+          cd nillion && cargo build -p test-programs
+      - name: Run nada autotests
+        run: |
+          pip install nillion/nada-lang/nada_dsl
+          mkdir target
+          cd nillion 
+          RUST_LOG=warn cargo run -p auto-tests


### PR DESCRIPTION
Fixes https://github.com/NillionNetwork/nada-lang/issues/37

## Changes

Adds an extra job to the PR pipeline that:
- checks that nillion test-programs builds with the current DSL
- Checks that autotests pass with the current DSL

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Backwards compatability analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
