### PR TITLE
feat: reduce the size of literal identifiers

### DIFF
--- a/nada_dsl/compiler_frontend.py
+++ b/nada_dsl/compiler_frontend.py
@@ -305,7 +305,7 @@ def process_operation(
         processed_operation = ProcessOperationOutput(operation.to_mir(), None)
     elif isinstance(operation, LiteralASTOperation):
 
-        LITERALS[operation.literal_name] = (str(operation.value), operation.ty)
+        LITERALS[operation.literal_index] = (str(operation.value), operation.ty)
         processed_operation = ProcessOperationOutput(operation.to_mir(), None)
     elif isinstance(
         operation, (MapASTOperation, ReduceASTOperation, NadaFunctionCallASTOperation)

--- a/nada_dsl/compiler_frontend_test.py
+++ b/nada_dsl/compiler_frontend_test.py
@@ -577,7 +577,6 @@ def test_binary_operator_integer_publicinteger(operator, name, ty):
     right_ast = AST_OPERATIONS[inner["right"]]
     assert isinstance(left_ast, LiteralASTOperation)
     assert left_ast.value == -3
-    assert len(left_ast.literal_name) == 32
     assert isinstance(right_ast, InputASTOperation)
     assert right_ast.name == "right"
     assert inner["type"] == to_type(ty)


### PR DESCRIPTION
Fixes #[15](https://github.com/NillionNetwork/nada-lang/issues/15)

## Changes

This reduces the size of literal identifiers from a md5 hash (32 bytes) into an index.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Backwards compatability analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
