### PR TITLE
Release v0.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nada_dsl"
-version = "0.6.3"
+version = "0.6.4"
 description = "Nillion Nada DSL to create Nillion MPC programs."
 requires-python = ">=3.10"
 readme = "README.pyproject.md"


### PR DESCRIPTION
Patch release 0.6.4
- Users can use Python builtin `sum` when working with integers. 
-bug fixes and internal chores. 

## Detailed changelog

- feat: reduce the size of literal identifiers (#37)
- chore: run validation tests from Nillion (#36)
- chore(deps): update sphinx-rtd-theme requirement (#34)
- fix: compiling nada functions overrides AST operations (#33)
- feat: Add deterministic operation and function identifiers (#31)
- chore: remove version.py file generation (#32)
- fix: compile nada functions that use literals (#29)
- feat: Add support for Python builtin sum (#25)
- chore: Update pylint version (#27)
- Update README.md (#26)
- fix: python linting errors (#22)
- docs: Add Github actions build status and PyPI version badge (#23)
- chore: Add issue templates (#21)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Backwards compatability analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
