### PR TITLE
feat: add support for ecdsa types and sign function

### DIFF
--- a/nada_dsl/compile_test.py
+++ b/nada_dsl/compile_test.py
@@ -7,7 +7,7 @@ import os
 import json
 import pytest
 from nada_dsl.ast_util import AST_OPERATIONS
-from nada_dsl.compile import compile_script, compile_string
+from nada_dsl.compile import compile_script, compile_string, print_output
 from nada_dsl.compiler_frontend import FUNCTIONS, INPUTS, PARTIES
 from nada_dsl.errors import NotAllowedException
 
@@ -161,3 +161,19 @@ def test_compile_map_simple():
                 raise Exception(f"Unexpected operation: {name}")
     assert map_inner > 0 and array_input_id > 0 and map_inner == array_input_id
     assert function_op_id > 0 and output_id == function_op_id
+
+def test_compile_ecdsa_program():
+    program_str = """
+from nada_dsl import *
+
+def nada_main():
+    party1 = Party(name="Party1")
+    private_key = EcdsaPrivateKey(Input(name="private_key", party=party1))
+    digest = EcdsaDigestMessage(Input(name="digest", party=party1))
+
+    new_int = private_key.ecdsa_sign(digest)
+    return [Output(new_int, "my_output", party1)]
+"""
+    encoded_program_str = base64.b64encode(bytes(program_str, "utf-8")).decode("utf_8")
+    output = compile_string(encoded_program_str)
+    print_output(output)

--- a/nada_dsl/nada_types/__init__.py
+++ b/nada_dsl/nada_types/__init__.py
@@ -38,6 +38,9 @@ AllTypes = Union[
     "Tuple",
     "NTuple",
     "Object",
+    "EcdsaPrivateKey",
+    "EcdsaDigestMessage",
+    "EcdsaSignature",
 ]
 AllTypesType = Union[
     Type["Integer"],
@@ -55,6 +58,9 @@ AllTypesType = Union[
     Type["Tuple"],
     Type["NTuple"],
     Type["Object"],
+    Type["EcdsaPrivateKey"],
+    Type["EcdsaDigestMessage"],
+    Type["EcdsaSignature"],
 ]
 OperationType = Union[
     "Addition",

--- a/nada_dsl/nada_types/scalar_types.py
+++ b/nada_dsl/nada_types/scalar_types.py
@@ -557,3 +557,35 @@ class SecretBoolean(BooleanType):
     def random(cls) -> "SecretBoolean":
         """Generate a random secret boolean."""
         return SecretBoolean(inner=Random(source_ref=SourceRef.back_frame()))
+
+
+@dataclass
+class EcdsaSignature(NadaType):
+    """The EcdsaSignature Nada MIR type."""
+
+    def __init__(self, inner: OperationType):
+        super().__init__(inner=inner)
+
+
+@dataclass
+class EcdsaDigestMessage(NadaType):
+    """The EcdsaDigestMessage Nada MIR type."""
+
+    def __init__(self, inner: OperationType):
+        super().__init__(inner=inner)
+
+
+@dataclass
+class EcdsaPrivateKey(NadaType):
+    """The EcdsaPrivateKey Nada MIR type."""
+
+    def __init__(self, inner: OperationType):
+        super().__init__(inner=inner)
+
+    def ecdsa_sign(self, digest: "EcdsaDigestMessage") -> "EcdsaSignature":
+        """Random operation for Secret integers."""
+        return EcdsaSignature(
+                inner=EcdsaSign(
+                        left=self, right=digest, source_ref=SourceRef.back_frame()
+                )
+        )

--- a/nada_dsl/operations.py
+++ b/nada_dsl/operations.py
@@ -191,3 +191,6 @@ class Not(UnaryOperation):
 
     def __init__(self, this: AllTypes, source_ref: SourceRef):
         super().__init__(inner=this, source_ref=source_ref)
+
+class EcdsaSign(BinaryOperation):
+    """Ecdsa signing operation."""


### PR DESCRIPTION
Adding support for `EcdsaSignature`, `EcdsaPrivateKey` and `EcdsaDigestMessage` types and `ecdsa_sign` function

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Backwards compatibility analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
