### PR TITLE
fix: `.to_public()` now doesn't underline for pyright

### DIFF
--- a/nada_dsl/nada_types/scalar_types.py
+++ b/nada_dsl/nada_types/scalar_types.py
@@ -2,7 +2,8 @@
 """The Nada Scalar type definitions."""
 
 from dataclasses import dataclass
-from typing import Any, Self, Union, TypeVar
+from typing import Any, Union, TypeVar
+from typing_extensions import Self
 from nada_dsl.operations import *
 from nada_dsl.program_io import Literal
 from nada_dsl import SourceRef

--- a/nada_dsl/nada_types/scalar_types.py
+++ b/nada_dsl/nada_types/scalar_types.py
@@ -12,9 +12,33 @@ from . import NadaType, Mode, BaseType, OperationType
 # Constant dictionary that stores all the Nada types and is use to
 # convert from the (mode, base_type) representation to the concrete Nada type
 # (Integer, SecretBoolean,...)
-_AnyScalarType = TypeVar("_AnyScalarType", 'Integer', 'UnsignedInteger', 'Boolean', 'PublicInteger', 'PublicUnsignedInteger', 'PublicBoolean', 'SecretInteger', 'SecretUnsignedInteger', 'SecretBoolean')
-AnyScalarType = Union['Integer', 'UnsignedInteger', 'Boolean', 'PublicInteger', 'PublicUnsignedInteger', 'PublicBoolean', 'SecretInteger', 'SecretUnsignedInteger', 'SecretBoolean']
+
+# pylint: disable=invalid-name
+_AnyScalarType = TypeVar("_AnyScalarType",
+                        'Integer',
+                        'UnsignedInteger',
+                        'Boolean',
+                        'PublicInteger',
+                        'PublicUnsignedInteger',
+                        'PublicBoolean',
+                        'SecretInteger',
+                        'SecretUnsignedInteger',
+                        'SecretBoolean')
+# pylint: enable=invalid-name
+
+AnyScalarType = Union['Integer',
+                    'UnsignedInteger',
+                    'Boolean',
+                    'PublicInteger',
+                    'PublicUnsignedInteger',
+                    'PublicBoolean',
+                    'SecretInteger',
+                    'SecretUnsignedInteger',
+                    'SecretBoolean']
+
+# pylint: disable=global-variable-not-assigned
 SCALAR_TYPES: dict[tuple[Mode, BaseType], type[AnyScalarType]] = {}
+# pylint: enable=global-variable-not-assigned
 
 AnyBoolean = Union['Boolean', 'PublicBoolean', 'SecretBoolean']
 
@@ -236,7 +260,7 @@ def binary_relational_operation(
         case Mode.CONSTANT:
             return new_scalar_type(mode, BaseType.BOOLEAN)(f(left.value, right.value)) # type: ignore
         case Mode.PUBLIC | Mode.SECRET:
-            inner = globals()[operation]( # TODO: Should we use globals() here?
+            inner = globals()[operation](
                 left=left, right=right, source_ref=SourceRef.back_frame()
             )
             return new_scalar_type(mode, BaseType.BOOLEAN)(inner) # type: ignore

--- a/nada_dsl/nada_types/scalar_types.py
+++ b/nada_dsl/nada_types/scalar_types.py
@@ -38,7 +38,6 @@ AnyScalarType = Union['Integer',
 
 # pylint: disable=global-variable-not-assigned
 SCALAR_TYPES: dict[tuple[Mode, BaseType], type[AnyScalarType]] = {}
-# pylint: enable=global-variable-not-assigned
 
 AnyBoolean = Union['Boolean', 'PublicBoolean', 'SecretBoolean']
 

--- a/nada_dsl/scalar_type_test.py
+++ b/nada_dsl/scalar_type_test.py
@@ -9,10 +9,6 @@ from nada_dsl.nada_types import BaseType, Mode
 from nada_dsl.nada_types.scalar_types import Integer, PublicInteger, SecretInteger, Boolean, PublicBoolean, \
     SecretBoolean, UnsignedInteger, PublicUnsignedInteger, SecretUnsignedInteger, ScalarType, BooleanType
 
-def test2_if_else(int1: SecretInteger, int2: SecretInteger) -> PublicInteger:
-    condition = (int1 > int2)
-    return condition.if_else(int1, int2).to_public()
-
 def combine_lists(list1, list2):
     """This returns all combinations for the items of two lists"""
     result = []
@@ -269,7 +265,7 @@ def test_random(operand):
 
 
 # Allowed types that can invoke the to_public() function.
-to_public_operands = secret_integers + secret_unsigned_integers + secret_booleans
+to_public_operands = integers + unsigned_integers + booleans
 
 
 @pytest.mark.parametrize("operand", to_public_operands)

--- a/nada_dsl/scalar_type_test.py
+++ b/nada_dsl/scalar_type_test.py
@@ -9,6 +9,9 @@ from nada_dsl.nada_types import BaseType, Mode
 from nada_dsl.nada_types.scalar_types import Integer, PublicInteger, SecretInteger, Boolean, PublicBoolean, \
     SecretBoolean, UnsignedInteger, PublicUnsignedInteger, SecretUnsignedInteger, ScalarType, BooleanType
 
+def test2_if_else(int1: SecretInteger, int2: SecretInteger) -> PublicInteger:
+    condition = (int1 > int2)
+    return condition.if_else(int1, int2).to_public()
 
 def combine_lists(list1, list2):
     """This returns all combinations for the items of two lists"""

--- a/nada_dsl/scalar_type_test.py
+++ b/nada_dsl/scalar_type_test.py
@@ -442,18 +442,6 @@ def test_not_allowed_random(operand):
         operand.random()
     assert invalid_operation.type == AttributeError
 
-
-# List of types that cannot invoke the function to_public()
-to_public_operands = public_booleans + public_integers + public_unsigned_integers
-
-
-@pytest.mark.parametrize("operand", to_public_operands)
-def test_not_to_public(operand):
-    with pytest.raises(Exception) as invalid_operation:
-        operand.to_public()
-    assert invalid_operation.type == AttributeError
-
-
 # List of operands that the function if_else does not accept
 not_allowed_if_else_operands = (
         # Boolean branches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev-dependencies = [
     "nada-mir-proto[dev]",
     "tomli",
     "requests",
+    "typing_extensions~=4.12.2",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.7.0"
 description = "Nillion Nada DSL to create Nillion MPC programs."
 requires-python = ">=3.10"
 readme = "README.pyproject.md"
-dependencies = ["asttokens~=2.4", "richreports~=0.2", "parsial~=0.1", "sortedcontainers~=2.4"]
+dependencies = ["asttokens~=2.4", "richreports~=0.2", "parsial~=0.1", "sortedcontainers~=2.4", "typing_extensions~=4.12.2"]
 classifiers = ["License :: OSI Approved :: Apache Software License"]
 license = { file = "LICENSE" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nada_dsl"
-version = "0.7.0"
+version = "0.7.1"
 description = "Nillion Nada DSL to create Nillion MPC programs."
 requires-python = ">=3.10"
 readme = "README.pyproject.md"


### PR DESCRIPTION
`.to_public()` now doesn't underline for pyright plus some other typing improvements. It makes `.to_public()` an idempotent function if the value is already public.