### PR TITLE
chore: Release notes script

### DIFF
--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,69 @@
+# Creates a JSON formatted list of release notes. It follows the same format
+# as in the GitHub API.
+#
+# Changes are split into categories:
+# - `breaking_changes`, has the list of breaking changes
+# - `bug_fixes`,
+# - `new_features`,
+# - `other`
+#
+# USAGE: pass an initial and final reference to generate release notes
+# `release_notes.py v0.6.1 v0.7.0` will generate the release notes for versions between v0.6.1 and v0.7.0
+#
+# Motivation: While GitHub generates the release notes between releases, this tool can generate release notes between any two references.
+
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class ReleaseNotes:
+    breaking_changes: list[str]
+    bug_fixes: list[str]
+    new_features: list[str]
+    other: list[str]
+
+    def to_json(self) -> str:
+        json_map = {
+            "breaking_changes": self.breaking_changes,
+            "bug_fixes": self.bug_fixes,
+            "new_features": self.new_features,
+            "other": self.other,
+        }
+        return json.dumps(json_map)
+
+
+def parse_git_log(initial_tag: str, final_tag: str):
+    git_output = subprocess.Popen(
+        ["git", "--no-pager", "log", "--oneline", f"{initial_tag}..{final_tag}"],
+        bufsize=0,
+        stdout=subprocess.PIPE,
+    )
+    release_notes = ReleaseNotes(
+        breaking_changes=[], bug_fixes=[], new_features=[], other=[]
+    )
+    while True:
+        line = git_output.stdout.readline().decode("utf-8")
+        if not line:
+            break
+        # Remove commit SHA
+        line = line[(line.index(" ") + 1) :]
+        if line.startswith("feat!:"):
+            release_notes.breaking_changes.append(line)
+        elif line.startswith("fix:"):
+            release_notes.bug_fixes.append(line)
+        elif line.startswith("feat:"):
+            release_notes.new_features.append(line)
+        else:
+            release_notes.other.append(line)
+
+    git_output.stdout.close()
+    git_output.wait()
+    print(release_notes.to_json())
+
+
+if __name__ == "__main__":
+    parse_git_log(sys.argv[1], sys.argv[2])

--- a/uv.lock
+++ b/uv.lock
@@ -619,13 +619,14 @@ wheels = [
 
 [[package]]
 name = "nada-dsl"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "asttokens" },
     { name = "parsial" },
     { name = "richreports" },
     { name = "sortedcontainers" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -653,6 +654,7 @@ dev = [
     { name = "sphinx-rtd-theme" },
     { name = "toml" },
     { name = "tomli" },
+    { name = "typing-extensions" },
 ]
 
 [package.metadata]
@@ -667,6 +669,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=5,<9" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=1.0,<3.1" },
     { name = "toml", marker = "extra == 'docs'", specifier = "~=0.10.2" },
+    { name = "typing-extensions", specifier = "~=4.12.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -680,6 +683,7 @@ dev = [
     { name = "sphinx-rtd-theme", specifier = ">=1.0,<3.1" },
     { name = "toml", specifier = "~=0.10.2" },
     { name = "tomli" },
+    { name = "typing-extensions", specifier = "~=4.12.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

Adds a script that generates release notes in JSON format. Works with any two git references. This script is useful to create release notes between two Nillion SDK releases.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Backwards compatibility analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
