### PR TITLE
chore: various renames and fixes

### DIFF
--- a/nada_dsl/ast_util.py
+++ b/nada_dsl/ast_util.py
@@ -43,8 +43,8 @@ class ASTOperation(ABC):
     source_ref: SourceRef
     ty: NadaTypeRepr
 
-    def inner_operations(self) -> List[int]:
-        """Returns the list of identifiers of all the inner operations of this operation."""
+    def child_operations(self) -> List[int]:
+        """Returns the list of identifiers of all the child operations of this operation."""
         return []
 
     def to_mir(self):
@@ -68,7 +68,7 @@ class BinaryASTOperation(ASTOperation):
     left: int
     right: int
 
-    def inner_operations(self) -> List[int]:
+    def child_operations(self) -> List[int]:
         return [self.left, self.right]
 
     def to_mir(self):
@@ -88,17 +88,17 @@ class UnaryASTOperation(ASTOperation):
     """Superclass of all the unary operations in AST representation"""
 
     name: str
-    inner: int
+    child: int
 
-    def inner_operations(self):
-        return [self.inner]
+    def child_operations(self):
+        return [self.child]
 
     def to_mir(self):
 
         return {
             self.name: {
                 "id": self.id,
-                "this": self.inner,
+                "this": self.child,
                 "type": self.ty,
                 "source_ref_index": self.source_ref.to_index(),
             }
@@ -109,20 +109,20 @@ class UnaryASTOperation(ASTOperation):
 class IfElseASTOperation(ASTOperation):
     """AST Representation of an IfElse operation."""
 
-    this: int
-    arg_0: int
-    arg_1: int
+    condition: int
+    true_branch_child: int
+    false_branch_child: int
 
-    def inner_operations(self):
-        return [self.this, self.arg_0, self.arg_1]
+    def child_operations(self):
+        return [self.condition, self.true_branch_child, self.false_branch_child]
 
     def to_mir(self):
         return {
             "IfElse": {
                 "id": self.id,
-                "this": self.this,
-                "arg_0": self.arg_0,
-                "arg_1": self.arg_1,
+                "this": self.condition,
+                "arg_0": self.true_branch_child,
+                "arg_1": self.false_branch_child,
                 "type": self.ty,
                 "source_ref_index": self.source_ref.to_index(),
             }
@@ -133,7 +133,7 @@ class IfElseASTOperation(ASTOperation):
 class RandomASTOperation(ASTOperation):
     """AST Representation of a Random operation."""
 
-    def inner_operations(self):
+    def child_operations(self):
         return []
 
     def to_mir(self):
@@ -215,19 +215,19 @@ class LiteralASTOperation(ASTOperation):
 class ReduceASTOperation(ASTOperation):
     """AST Representation of a Reduce operation."""
 
-    inner: int
+    child: int
     fn: int
     initial: int
 
-    def inner_operations(self):
-        return [self.inner, self.initial]
+    def child_operations(self):
+        return [self.child, self.initial]
 
     def to_mir(self):
         return {
             "Reduce": {
                 "id": self.id,
                 "fn": self.fn,
-                "inner": self.inner,
+                "inner": self.child,
                 "initial": self.initial,
                 "type": self.ty,
                 "source_ref_index": self.source_ref.to_index(),
@@ -239,18 +239,18 @@ class ReduceASTOperation(ASTOperation):
 class MapASTOperation(ASTOperation):
     """AST representation of a Map operation."""
 
-    inner: int
+    child: int
     fn: int
 
-    def inner_operations(self):
-        return [self.inner]
+    def child_operations(self):
+        return [self.child]
 
     def to_mir(self):
         return {
             "Map": {
                 "id": self.id,
                 "fn": self.fn,
-                "inner": self.inner,
+                "inner": self.child,
                 "type": self.ty,
                 "source_ref_index": self.source_ref.to_index(),
             }
@@ -263,9 +263,8 @@ class NewASTOperation(ASTOperation):
 
     name: str
     elements: List[int]
-    inner_type: object
 
-    def inner_operations(self):
+    def child_operations(self):
         return self.elements
 
     def to_mir(self):
@@ -286,7 +285,7 @@ class NadaFunctionCallASTOperation(ASTOperation):
     args: List[int]
     fn: int
 
-    def inner_operations(self):
+    def child_operations(self):
         return self.args
 
     def to_mir(self):
@@ -327,7 +326,7 @@ class NadaFunctionASTOperation(ASTOperation):
 
     name: str
     args: List[int]
-    inner: int
+    child: int
 
     # pylint: disable=arguments-differ
     def to_mir(self, operations):
@@ -347,7 +346,7 @@ class NadaFunctionASTOperation(ASTOperation):
                 for arg in arg_operations
             ],
             "function": self.name,
-            "return_operation_id": self.inner,
+            "return_operation_id": self.child,
             "operations": operations,
             "return_type": self.ty,
             "source_ref_index": self.source_ref.to_index(),
@@ -364,7 +363,7 @@ class CastASTOperation(ASTOperation):
 
     target: int
 
-    def inner_operations(self):
+    def child_operations(self):
         return [self.target]
 
     def to_mir(self):

--- a/nada_dsl/compiler_frontend.py
+++ b/nada_dsl/compiler_frontend.py
@@ -81,7 +81,7 @@ def nada_dsl_to_nada_mir(outputs: List[Output]) -> Dict[str, Any]:
         timer.start(
             f"nada_dsl.compiler_frontend.nada_dsl_to_nada_mir.{output.name}.process_operation"
         )
-        out_operation_id = output.inner.inner.id
+        out_operation_id = output.child.child.id
         extra_fns = traverse_and_process_operations(
             out_operation_id, operations, FUNCTIONS
         )
@@ -184,7 +184,7 @@ def to_mir_function_list(functions: Dict[int, NadaFunctionASTOperation]) -> List
         function_operations = {}
 
         extra_functions = traverse_and_process_operations(
-            function.inner,
+            function.child,
             function_operations,
             functions,
         )
@@ -255,7 +255,7 @@ def traverse_and_process_operations(
                 extra_functions[wrapped_operation.extra_function.id] = (
                     wrapped_operation.extra_function
                 )
-            stack.extend(operation.inner_operations())
+            stack.extend(operation.child_operations())
     return extra_functions
 
 

--- a/nada_dsl/nada_types/__init__.py
+++ b/nada_dsl/nada_types/__init__.py
@@ -90,7 +90,7 @@ NadaTypeRepr: TypeAlias = str | Dict[str, Dict]
 """Type alias for the NadaType representation. 
 
 This representation can be either a string ("SecretInteger") 
-or a dictionary (Array{inner_type=SecretInteger, size=3}).
+or a dictionary (Array{contained_types=SecretInteger, size=3}).
 """
 
 
@@ -121,7 +121,7 @@ class NadaType:
     This is the parent class of all nada types.
 
     In Nada, all the types wrap Operations. For instance, an addition between two integers
-    is represented like this SecretInteger(inner=Addition(...)).
+    is represented like this SecretInteger(child=Addition(...)).
 
     In MIR, the representation is based around operations. A MIR operation points to other
     operations and has a return type.
@@ -130,25 +130,25 @@ class NadaType:
     MIR-friendly format, as subclasses of ASTOperation.
 
     Whenever the Python interpreter constructs an instance of NadaType, it will also store
-    in memory the corresponding inner operation. In order to do so, the ASTOperation will
+    in memory the corresponding child operation. In order to do so, the ASTOperation will
     need the type in MIR format. Which is why all instances of `NadaType` provide an implementation
-    of `to_type()`.
+    of `to_mir()`.
 
     """
 
-    inner: OperationType
+    child: OperationType
 
-    def __init__(self, inner: OperationType):
+    def __init__(self, child: OperationType):
         """NadaType default constructor
 
         Args:
-            inner (OperationType): The inner operation of this Data type
+            child (OperationType): The child operation of this Data type
         """
-        self.inner = inner
-        if self.inner is not None:
-            self.inner.store_in_ast(self.to_type())
+        self.child = child
+        if self.child is not None:
+            self.child.store_in_ast(self.to_mir())
 
-    def to_type(self):
+    def to_mir(self):
         """Default implementation for the Conversion of a type into MIR representation."""
         return self.__class__.class_to_type()
 
@@ -163,3 +163,13 @@ class NadaType:
 
     def __bool__(self):
         raise NotImplementedError
+
+    @classmethod
+    def is_scalable(cls) -> bool:
+        """Returns True if the type is a scalable."""
+        return False
+
+    @classmethod
+    def is_literal(cls) -> bool:
+        """Returns True if the type is a literal."""
+        return False

--- a/nada_dsl/operations.py
+++ b/nada_dsl/operations.py
@@ -29,8 +29,8 @@ class BinaryOperation:
         AST_OPERATIONS[self.id] = BinaryASTOperation(
             id=self.id,
             name=self.__class__.__name__,
-            left=self.left.inner.id,
-            right=self.right.inner.id,
+            left=self.left.child.id,
+            right=self.right.child.id,
             source_ref=self.source_ref,
             ty=ty,
         )
@@ -39,9 +39,9 @@ class BinaryOperation:
 class UnaryOperation:
     """Superclass of all the unary operations."""
 
-    def __init__(self, inner: AllTypes, source_ref: SourceRef):
+    def __init__(self, child: AllTypes, source_ref: SourceRef):
         self.id = next_operation_id()
-        self.inner = inner
+        self.child = child
         self.source_ref = source_ref
 
     def store_in_ast(self, ty: object):
@@ -49,7 +49,7 @@ class UnaryOperation:
         AST_OPERATIONS[self.id] = UnaryASTOperation(
             id=self.id,
             name=self.__class__.__name__,
-            inner=self.inner.inner.id,
+            child=self.child.child.id,
             source_ref=self.source_ref,
             ty=ty,
         )
@@ -167,9 +167,9 @@ class IfElse:
         """Store object in AST."""
         AST_OPERATIONS[self.id] = IfElseASTOperation(
             id=self.id,
-            this=self.this.inner.id,
-            arg_0=self.arg_0.inner.id,
-            arg_1=self.arg_1.inner.id,
+            condition=self.this.child.id,
+            true_branch_child=self.arg_0.child.id,
+            false_branch_child=self.arg_1.child.id,
             ty=ty,
             source_ref=self.source_ref,
         )
@@ -179,7 +179,7 @@ class Reveal(UnaryOperation):
     """Reveal (i.e. make public) operation."""
 
     def __init__(self, this: AllTypes, source_ref: SourceRef):
-        super().__init__(inner=this, source_ref=source_ref)
+        super().__init__(child=this, source_ref=source_ref)
 
 
 class TruncPr(BinaryOperation):
@@ -190,7 +190,8 @@ class Not(UnaryOperation):
     """Not (!) Operation"""
 
     def __init__(self, this: AllTypes, source_ref: SourceRef):
-        super().__init__(inner=this, source_ref=source_ref)
+        super().__init__(child=this, source_ref=source_ref)
+
 
 class EcdsaSign(BinaryOperation):
     """Ecdsa signing operation."""

--- a/nada_dsl/program_io.py
+++ b/nada_dsl/program_io.py
@@ -39,9 +39,9 @@ class Input(NadaType):
         self.name = name
         self.party = party
         self.doc = doc
-        self.inner = None
+        self.child = None
         self.source_ref = SourceRef.back_frame()
-        super().__init__(self.inner)
+        super().__init__(self.child)
 
     def store_in_ast(self, ty: object):
         """Store object in AST"""
@@ -70,8 +70,8 @@ class Literal(NadaType):
         self.id = next_operation_id()
         self.value = value
         self.source_ref = source_ref
-        self.inner = None
-        super().__init__(self.inner)
+        self.child = None
+        super().__init__(self.child)
 
     def store_in_ast(self, ty: object):
         """Store object in AST"""
@@ -90,24 +90,24 @@ class Output:
     Represents an output from the computation.
 
     Attributes:
-        inner (AllTypes): The type of the output.
+        child (AllTypes): The type of the output.
         party (Party): The party receiving the output.
         name (str): The name of the output.
     """
 
-    inner: AllTypes
+    child: AllTypes
     party: Party
     name: str
     source_ref: SourceRef
 
-    def __init__(self, inner, name, party):
+    def __init__(self, child, name, party):
         self.source_ref = SourceRef.back_frame()
-        if not issubclass(type(inner), NadaType):
+        if not issubclass(type(child), NadaType):
             raise InvalidTypeError(
                 f"{self.source_ref.file}:{self.source_ref.lineno}: Output value "
-                f"{inner} of type {type(inner)} is not "
+                f"{child} of type {type(child)} is not "
                 f"a Nada type so it isn't a valid output"
             )
-        self.inner = inner
+        self.child = child
         self.name = name
         self.party = party

--- a/tests/compile_test.py
+++ b/tests/compile_test.py
@@ -162,6 +162,7 @@ def test_compile_map_simple():
     assert map_inner > 0 and array_input_id > 0 and map_inner == array_input_id
     assert function_op_id > 0 and output_id == function_op_id
 
+
 def test_compile_ecdsa_program():
     program_str = """
 from nada_dsl import *


### PR DESCRIPTION
## Changes

* removes a few class attributes definition (they should be instance attributes instead)
* renames `inner` to `child` (`producer` was also considered, but `child` is more idiomatic in the context of an AST)
* renames `inner_type` to `contained_type` in compound types (we are now storing more than one type in compound types) and removed `inner_type` from operations
* renames `to_type` to `to_mir`
* adds `is_scalar` and `is_literal` (will be used in a follow up PR)

Note that this doesn't break the MIR. We will do the necessary changes in a follow up PR, as well as in another PR in the main nillion repo so that it is able to interpret the changes.

You can review each commit separately instead of all changes at once if you want, should be easier to read.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Backwards compatibility analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
