### PR TITLE
ci: Use GitHub App authentication to checkout nillion repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,21 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
+      - name: Generate Nillion Repo app token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.NILLION_REPO_APP_ID }}
+          owner: NillionNetwork
+          private-key: ${{ secrets.NILLION_REPO_APP_PRIVATE_KEY }}
+          repositories: nillion
       - name: Checkout tools repo
         uses: actions/checkout@v4
         with:
           repository: NillionNetwork/nillion
           path: nillion
-          token: ${{ secrets.NILLION_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
+          ref: main
       - name: Replace nillion's nada_dsl with this version
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Changes

This commit switches the `build.yml` workflow over to use GitHub App tokens to checkout the nillion repo (private) instead of relying on PATs, which expire and have to be manually rotated.

Instead, I created a GitHub App named "Nillion Repo" at the org-level. I gave the app read-only access to the nillion repo. And I added the app's ID and private key to the nada-dsl repo:

* As a variable: `NILLION_REPO_APP_ID`
* And as a secret: `NILLION_REPO_APP_PRIVATE_KEY`

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Backwards compatibility analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"