### PR TITLE
feat: add accessors for NTuple and Object

### DIFF
--- a/nada_dsl/ast_util.py
+++ b/nada_dsl/ast_util.py
@@ -376,3 +376,47 @@ class CastASTOperation(ASTOperation):
                 "source_ref_index": self.source_ref.to_index(),
             }
         }
+
+
+@dataclass
+class NTupleAccessorASTOperation(ASTOperation):
+    """AST representation of a n tuple accessor operation."""
+
+    index: int
+    source: int
+
+    def child_operations(self):
+        return [self.source]
+
+    def to_mir(self):
+        return {
+            "NTupleAccessor": {
+                "id": self.id,
+                "index": self.index,
+                "source": self.source,
+                "type": self.ty,
+                "source_ref_index": self.source_ref.to_index(),
+            }
+        }
+
+
+@dataclass
+class ObjectAccessorASTOperation(ASTOperation):
+    """AST representation of an object accessor operation."""
+
+    key: str
+    source: int
+
+    def child_operations(self):
+        return [self.source]
+
+    def to_mir(self):
+        return {
+            "ObjectAccessor": {
+                "id": self.id,
+                "key": self.key,
+                "source": self.source,
+                "type": self.ty,
+                "source_ref_index": self.source_ref.to_index(),
+            }
+        }

--- a/nada_dsl/compiler_frontend.py
+++ b/nada_dsl/compiler_frontend.py
@@ -20,10 +20,12 @@ from nada_dsl.ast_util import (
     InputASTOperation,
     LiteralASTOperation,
     MapASTOperation,
+    NTupleAccessorASTOperation,
     NadaFunctionASTOperation,
     NadaFunctionArgASTOperation,
     NadaFunctionCallASTOperation,
     NewASTOperation,
+    ObjectAccessorASTOperation,
     RandomASTOperation,
     ReduceASTOperation,
     UnaryASTOperation,
@@ -296,6 +298,8 @@ def process_operation(
             NewASTOperation,
             RandomASTOperation,
             NadaFunctionArgASTOperation,
+            NTupleAccessorASTOperation,
+            ObjectAccessorASTOperation,
         ),
     ):
         processed_operation = ProcessOperationOutput(operation.to_mir(), None)

--- a/nada_dsl/nada_types/__init__.py
+++ b/nada_dsl/nada_types/__init__.py
@@ -150,10 +150,10 @@ class NadaType:
 
     def to_mir(self):
         """Default implementation for the Conversion of a type into MIR representation."""
-        return self.__class__.class_to_type()
+        return self.__class__.class_to_mir()
 
     @classmethod
-    def class_to_type(cls) -> str:
+    def class_to_mir(cls) -> str:
         """Converts a class into a MIR Nada type."""
         name = cls.__name__
         # Rename public variables so they are considered as the same as literals.
@@ -165,8 +165,8 @@ class NadaType:
         raise NotImplementedError
 
     @classmethod
-    def is_scalable(cls) -> bool:
-        """Returns True if the type is a scalable."""
+    def is_scalar(cls) -> bool:
+        """Returns True if the type is a scalar."""
         return False
 
     @classmethod

--- a/nada_dsl/nada_types/function.py
+++ b/nada_dsl/nada_types/function.py
@@ -101,7 +101,7 @@ class NadaFunction(Generic[T, R]):
             name=self.function.__name__,
             args=[arg.id for arg in self.args],
             id=self.id,
-            ty=self.return_type.class_to_type(),
+            ty=self.return_type.class_to_mir(),
             source_ref=self.source_ref,
             child=self.child.child.id,
         )
@@ -125,7 +125,7 @@ class NadaFunctionCall(Generic[R]):
         self.args = args
         self.fn = nada_function
         self.source_ref = source_ref
-        self.store_in_ast(nada_function.return_type.class_to_type())
+        self.store_in_ast(nada_function.return_type.class_to_mir())
 
     def store_in_ast(self, ty):
         """Store this function call in the AST."""

--- a/nada_dsl/nada_types/scalar_types.py
+++ b/nada_dsl/nada_types/scalar_types.py
@@ -77,7 +77,7 @@ class ScalarType(NadaType):
         return self
 
     @classmethod
-    def is_scalable(cls) -> bool:
+    def is_scalar(cls) -> bool:
         return True
 
 

--- a/test-programs/ntuple_accessor.py
+++ b/test-programs/ntuple_accessor.py
@@ -1,0 +1,24 @@
+from nada_dsl import *
+
+
+def nada_main():
+    party1 = Party(name="Party1")
+    my_int1 = PublicInteger(Input(name="my_int1", party=party1))
+    my_int2 = PublicInteger(Input(name="my_int2", party=party1))
+
+    array = Array.new(my_int1, my_int1)
+
+    # Store a scalar, a compound type and a literal.
+    tuple = NTuple.new([my_int1, array, Integer(42)])
+
+    scalar = tuple[0]
+    array = tuple[1]
+    literal = tuple[2]
+
+    @nada_fn
+    def add(a: PublicInteger) -> PublicInteger:
+        return a + my_int2
+
+    sum = array.reduce(add, Integer(0))
+
+    return [Output(scalar + literal + sum, "my_output", party1)]

--- a/test-programs/object_accessor.py
+++ b/test-programs/object_accessor.py
@@ -1,0 +1,24 @@
+from nada_dsl import *
+
+
+def nada_main():
+    party1 = Party(name="Party1")
+    my_int1 = PublicInteger(Input(name="my_int1", party=party1))
+    my_int2 = PublicInteger(Input(name="my_int2", party=party1))
+
+    array = Array.new(my_int1, my_int1)
+
+    # Store a scalar, a compound type and a literal.
+    object = Object.new({"a": my_int1, "b": array, "c": Integer(42)})
+
+    scalar = object.a
+    array = object.b
+    literal = object.c
+
+    @nada_fn
+    def add(a: PublicInteger) -> PublicInteger:
+        return a + my_int2
+
+    sum = array.reduce(add, Integer(0))
+
+    return [Output(scalar + literal + sum, "my_output", party1)]

--- a/tests/compile_test.py
+++ b/tests/compile_test.py
@@ -178,3 +178,13 @@ def nada_main():
     encoded_program_str = base64.b64encode(bytes(program_str, "utf-8")).decode("utf_8")
     output = compile_string(encoded_program_str)
     print_output(output)
+
+
+def test_compile_ntuple():
+    mir_str = compile_script(f"{get_test_programs_folder()}/ntuple_accessor.py").mir
+    assert mir_str != ""
+
+
+def test_compile_object():
+    mir_str = compile_script(f"{get_test_programs_folder()}/object_accessor.py").mir
+    assert mir_str != ""

--- a/tests/nada_type_test.py
+++ b/tests/nada_type_test.py
@@ -13,6 +13,6 @@ from nada_dsl.nada_types.scalar_types import Integer, PublicBoolean, SecretInteg
         (PublicBoolean, "Boolean"),
     ],
 )
-def test_class_to_type(cls: NadaType, expected: str):
-    """Tests `NadaType.class_to_type()"""
-    assert cls.class_to_type() == expected
+def test_class_to_mir(cls: NadaType, expected: str):
+    """Tests `NadaType.class_to_mir()"""
+    assert cls.class_to_mir() == expected


### PR DESCRIPTION
Fixes https://github.com/NillionNetwork/nada-lang/issues/50

## Changes

This adds accessors for the NTuple and Object compound types. This is a prerequisite for implementing Documents.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Backwards compatibility analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
