### PR TITLE
fix: back frame in abstracted operations as functions

### DIFF
--- a/nada_dsl/nada_types/scalar_types.py
+++ b/nada_dsl/nada_types/scalar_types.py
@@ -94,12 +94,12 @@ def equals_operation(
             return Boolean(value=bool(f(left.value, right.value)))
         case Mode.PUBLIC:
             operation = globals()[operation](
-                left=left, right=right, source_ref=SourceRef.back_frame()
+                left=left, right=right, source_ref=SourceRef.back_frame().back_frame()
             )
             return PublicBoolean(child=operation)
         case Mode.SECRET:
             operation = globals()[operation](
-                left=left, right=right, source_ref=SourceRef.back_frame()
+                left=left, right=right, source_ref=SourceRef.back_frame().back_frame()
             )
             return SecretBoolean(child=operation)
 
@@ -227,7 +227,7 @@ def binary_arithmetic_operation(
             return new_scalar_type(mode, base_type)(f(left.value, right.value))
         case Mode.PUBLIC | Mode.SECRET:
             child = globals()[operation](
-                left=left, right=right, source_ref=SourceRef.back_frame()
+                left=left, right=right, source_ref=SourceRef.back_frame().back_frame()
             )
             return new_scalar_type(mode, base_type)(child)
 
@@ -249,7 +249,7 @@ def shift_operation(
             return new_scalar_type(mode, base_type)(f(left.value, right.value))
         case Mode.PUBLIC | Mode.SECRET:
             child = globals()[operation](
-                left=left, right=right, source_ref=SourceRef.back_frame()
+                left=left, right=right, source_ref=SourceRef.back_frame().back_frame()
             )
             return new_scalar_type(mode, base_type)(child)
 
@@ -267,7 +267,7 @@ def binary_relational_operation(
             return new_scalar_type(mode, BaseType.BOOLEAN)(f(left.value, right.value))  # type: ignore
         case Mode.PUBLIC | Mode.SECRET:
             child = globals()[operation](
-                left=left, right=right, source_ref=SourceRef.back_frame()
+                left=left, right=right, source_ref=SourceRef.back_frame().back_frame()
             )
             return new_scalar_type(mode, BaseType.BOOLEAN)(child)  # type: ignore
 
@@ -282,7 +282,7 @@ def public_equals_operation(left: ScalarType, right: ScalarType) -> "PublicBoole
 
     return PublicBoolean(
         child=PublicOutputEquality(
-            left=left, right=right, source_ref=SourceRef.back_frame()
+            left=left, right=right, source_ref=SourceRef.back_frame().back_frame()
         )  # type: ignore
     )
 
@@ -338,12 +338,12 @@ def binary_logical_operation(
         return Boolean(value=bool(f(left.value, right.value)))
     if mode == Mode.PUBLIC:
         operation = globals()[operation](
-            left=left, right=right, source_ref=SourceRef.back_frame()
+            left=left, right=right, source_ref=SourceRef.back_frame().back_frame()
         )
         return PublicBoolean(child=operation)
 
     operation = globals()[operation](
-        left=left, right=right, source_ref=SourceRef.back_frame()
+        left=left, right=right, source_ref=SourceRef.back_frame().back_frame()
     )
     return SecretBoolean(child=operation)
 


### PR DESCRIPTION
# Fixes
Back frame in operations built in abstracted functions was pointing to the wrong frame, one back when it should be two frames back.
## Changes
Change all  abstracted operations functions to call backframe twice pointing to the right back frame
