### PR TITLE
feat: add ecdsa public key type and store id type

### DIFF
--- a/nada_mir/proto/nillion/nada/v1/types.proto
+++ b/nada_mir/proto/nillion/nada/v1/types.proto
@@ -52,5 +52,7 @@ message NadaType {
     Tuple tuple = 11;
     Ntuple ntuple = 12;
     Object object = 13;
+    google.protobuf.Empty ecdsa_public_key = 14;
+    google.protobuf.Empty store_id = 15;
   }
 }

--- a/nada_mir/src/nada_mir_proto/nillion/nada/types/v1/__init__.py
+++ b/nada_mir/src/nada_mir_proto/nillion/nada/types/v1/__init__.py
@@ -88,3 +88,9 @@ class NadaType(betterproto.Message):
     tuple: "Tuple" = betterproto.message_field(11, group="nada_type")
     ntuple: "Ntuple" = betterproto.message_field(12, group="nada_type")
     object: "Object" = betterproto.message_field(13, group="nada_type")
+    ecdsa_public_key: "betterproto_lib_google_protobuf.Empty" = (
+        betterproto.message_field(14, group="nada_type")
+    )
+    store_id: "betterproto_lib_google_protobuf.Empty" = betterproto.message_field(
+        15, group="nada_type"
+    )


### PR DESCRIPTION
This adds store id and ecdsa public key to nada-dsl. 

# Motivation
This is part of the ongoing work of adding DKG. It requires to output two types of the user: the store id where the ecdsa private key is saved and the corresponding ecdsa public key.

Fixes #
Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Backwards compatibility analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
