### PR TITLE
chore: udpate gh-action-sigstore-python version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,7 +121,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz


### PR DESCRIPTION
`sigstore/gh-action-sigstore-python@v2.1.1` uses `actions/upload-artifact@v3` that has been deprecated due to that, the github release fails.