### PR TITLE
fix: assign source to tuple accessors

### DIFF
--- a/nada_dsl/ast_util.py
+++ b/nada_dsl/ast_util.py
@@ -400,6 +400,7 @@ class TupleAccessorASTOperation(ASTOperation):
                 index=proto_op.TupleIndex.LEFT
                 if self.index == 0
                 else proto_op.TupleIndex.RIGHT,
+                source=self.source,
             ),
         )
 


### PR DESCRIPTION
This assigns source to TupleAccessors. We didn't assign it and all accessors were created over the operation with id = 0 instead of the tuple.
