### PR TITLE
feat: add support for eddsa types and sign function

### DIFF
--- a/nada_dsl/compiler_frontend.py
+++ b/nada_dsl/compiler_frontend.py
@@ -417,10 +417,20 @@ def type_to_str(ty: proto_ty.NadaType):
         return "SecretBoolean"
     if hasattr(ty, "ecdsa_private_key"):
         return "EcdsaPrivateKey"
+    if hasattr(ty, "ecdsa_public_key"):
+        return "EcdsaPublicKey"
     if hasattr(ty, "ecdsa_digest_message"):
         return "EcdsaDigestMessage"
     if hasattr(ty, "ecdsa_signature"):
         return "EcdsaSignature"
+    if hasattr(ty, "eddsa_private_key"):
+        return "EddsaPrivateKey"
+    if hasattr(ty, "eddsa_public_key"):
+        return "EddsaPublicKey"
+    if hasattr(ty, "eddsa_message"):
+        return "EddsaMessage"
+    if hasattr(ty, "eddsa_signature"):
+        return "EddsaSignature"
     if hasattr(ty, "array"):
         return f"Array[{type_to_str(ty.collection.contained_type)}:{ty.collection.array.size}]"
     if hasattr(ty, "tuple"):

--- a/nada_dsl/nada_types/__init__.py
+++ b/nada_dsl/nada_types/__init__.py
@@ -39,8 +39,13 @@ AllTypes = Union[
     "NTuple",
     "Object",
     "EcdsaPrivateKey",
+    "EcdsaPublicKey",
     "EcdsaDigestMessage",
     "EcdsaSignature",
+    "EddsaPrivateKey",
+    "EddsaPublicKey",
+    "EddsaMessage",
+    "EddsaSignature",
 ]
 AllTypesType = Union[
     Type["Integer"],
@@ -58,8 +63,13 @@ AllTypesType = Union[
     Type["NTuple"],
     Type["Object"],
     Type["EcdsaPrivateKey"],
+    Type["EcdsaPublicKey"],
     Type["EcdsaDigestMessage"],
     Type["EcdsaSignature"],
+    Type["EddsaPrivateKey"],
+    Type["EddsaPublicKey"],
+    Type["EddsaMessage"],
+    Type["EddsaSignature"],
 ]
 OperationType = Union[
     "Addition",

--- a/nada_dsl/nada_types/scalar_types.py
+++ b/nada_dsl/nada_types/scalar_types.py
@@ -796,6 +796,11 @@ class EcdsaPrivateKey(DslType):
             child=EcdsaSign(left=self, right=digest, source_ref=SourceRef.back_frame())
         )
 
+    def public_key(self: "EcdsaPrivateKey") -> "EcdsaPublicKey":
+        """Get the public key corresponding to this private key."""
+        operation = PublicKeyDerive(this=self, source_ref=SourceRef.back_frame())
+        return EcdsaPublicKey(child=operation)
+
     def type(self):
         return EcdsaPrivateKeyType()
 
@@ -805,3 +810,104 @@ class EcdsaPrivateKeyType(TypePassthroughMixin):
 
     ty = EcdsaPrivateKey
     proto_ty = "ecdsa_private_key"
+
+
+@dataclass
+class EcdsaPublicKey(DslType):
+    """The EcdsaPublicKey Nada MIR type."""
+
+    def __init__(self, child: OperationType):
+        super().__init__(child=child)
+
+    def type(self):
+        return EcdsaPublicKeyType()
+
+
+class EcdsaPublicKeyType(TypePassthroughMixin):
+    """Meta type for EcdsaPublicKeys"""
+
+    ty = EcdsaPublicKey
+    proto_ty = "ecdsa_public_key"
+
+
+@dataclass
+class EddsaSignature(DslType):
+    """The EddsaSignature Nada MIR type."""
+
+    def __init__(self, child: OperationType):
+        super().__init__(child=child)
+
+    def type(self):
+        return EddsaSignatureType()
+
+
+class EddsaSignatureType(TypePassthroughMixin):
+    """Meta type for EddsaSignatures"""
+
+    ty = EddsaSignature
+    proto_ty = "eddsa_signature"
+
+
+@dataclass
+class EddsaMessage(DslType):
+    """The EddsaMessage Nada MIR type."""
+
+    def __init__(self, child: OperationType):
+        super().__init__(child=child)
+
+    def type(self):
+        return EddsaMessageType()
+
+
+class EddsaMessageType(TypePassthroughMixin):
+    """Meta type for EddsaMessages"""
+
+    ty = EddsaMessage
+    proto_ty = "eddsa_message"
+
+
+@dataclass
+class EddsaPrivateKey(DslType):
+    """The EddsaPrivateKey Nada MIR type."""
+
+    def __init__(self, child: OperationType):
+        super().__init__(child=child)
+
+    def eddsa_sign(self, message: "EddsaMessage") -> "EddsaSignature":
+        """Random operation for Secret integers."""
+        return EddsaSignature(
+            child=EddsaSign(left=self, right=message, source_ref=SourceRef.back_frame())
+        )
+
+    def public_key(self: "EddsaPrivateKey") -> "EddsaPublicKey":
+        """Get the public key corresponding to this private key."""
+        operation = PublicKeyDerive(this=self, source_ref=SourceRef.back_frame())
+        return EddsaPublicKey(child=operation)
+
+    def type(self):
+        return EddsaPrivateKeyType()
+
+
+class EddsaPrivateKeyType(TypePassthroughMixin):
+    """Meta type for EddsaPrivateKeys"""
+
+    ty = EddsaPrivateKey
+    proto_ty = "eddsa_private_key"
+
+
+@dataclass
+class EddsaPublicKey(DslType):
+    """The EddsaPublicKey Nada MIR type."""
+
+    def __init__(self, child: OperationType):
+        super().__init__(child=child)
+
+    def type(self):
+        return EddsaPublicKeyType()
+
+
+class EddsaPublicKeyType(TypePassthroughMixin):
+    """Meta type for EddsaPublicKeys"""
+
+    ty = EddsaPublicKey
+    proto_ty = "eddsa_public_key"

--- a/nada_dsl/operations.py
+++ b/nada_dsl/operations.py
@@ -227,6 +227,15 @@ class Reveal(UnaryOperation):
         super().__init__(child=this, source_ref=source_ref)
 
 
+class PublicKeyDerive(UnaryOperation):
+    """Operation that derives a public key from its corresponding private key."""
+
+    variant = proto_op.UnaryOperationVariant.PUBLIC_KEY_DERIVE
+
+    def __init__(self, this: AllTypes, source_ref: SourceRef):
+        super().__init__(child=this, source_ref=source_ref)
+
+
 class TruncPr(BinaryOperation):
     """Probabilistic Truncation operation."""
 
@@ -246,3 +255,9 @@ class EcdsaSign(BinaryOperation):
     """Ecdsa signing operation."""
 
     variant = proto_op.BinaryOperationVariant.ECDSA_SIGN
+
+
+class EddsaSign(BinaryOperation):
+    """Eddsa signing operation."""
+
+    variant = proto_op.BinaryOperationVariant.EDDSA_SIGN

--- a/nada_mir/proto/nillion/nada/v1/operations.proto
+++ b/nada_mir/proto/nillion/nada/v1/operations.proto
@@ -52,6 +52,8 @@ enum BinaryOperationVariant {
   INNER_PRODUCT = 20;
   // ECDSA sign operation variant
   ECDSA_SIGN = 21;
+  // Eddsa sign operation variant
+  EDDSA_SIGN = 22;
 }
 
 // The variant of the binary operation.
@@ -62,6 +64,8 @@ enum UnaryOperationVariant {
   REVEAL = 1;
   // Not operation variant
   NOT = 2;
+  // Public key derive operation variant
+  PUBLIC_KEY_DERIVE = 3;
 }
 
 // MIR Binary operation.
@@ -81,6 +85,7 @@ message BinaryOperation {
 // - Not
 // - Reveal
 // - Unzip
+// - Public key derive
 message UnaryOperation {
   // Operation variant
   UnaryOperationVariant variant = 1;

--- a/nada_mir/proto/nillion/nada/v1/types.proto
+++ b/nada_mir/proto/nillion/nada/v1/types.proto
@@ -52,5 +52,10 @@ message NadaType {
     Tuple tuple = 11;
     Ntuple ntuple = 12;
     Object object = 13;
+    google.protobuf.Empty ecdsa_public_key = 14;
+    google.protobuf.Empty eddsa_private_key = 15;
+    google.protobuf.Empty eddsa_public_key = 16;
+    google.protobuf.Empty eddsa_message = 17;
+    google.protobuf.Empty eddsa_signature = 18;
   }
 }

--- a/nada_mir/src/nada_mir_proto/nillion/nada/operations/v1/__init__.py
+++ b/nada_mir/src/nada_mir_proto/nillion/nada/operations/v1/__init__.py
@@ -84,6 +84,9 @@ class BinaryOperationVariant(betterproto.Enum):
     ECDSA_SIGN = 21
     """ECDSA sign operation variant"""
 
+    EDDSA_SIGN = 22
+    """Eddsa sign operation variant"""
+
 
 class UnaryOperationVariant(betterproto.Enum):
     """The variant of the binary operation."""
@@ -96,6 +99,9 @@ class UnaryOperationVariant(betterproto.Enum):
 
     NOT = 2
     """Not operation variant"""
+
+    PUBLIC_KEY_DERIVE = 3
+    """Public key derive operation variant"""
 
 
 class TupleIndex(betterproto.Enum):
@@ -132,6 +138,7 @@ class UnaryOperation(betterproto.Message):
      - Not
      - Reveal
      - Unzip
+     - Public key derive
     """
 
     variant: "UnaryOperationVariant" = betterproto.enum_field(1)

--- a/nada_mir/src/nada_mir_proto/nillion/nada/types/v1/__init__.py
+++ b/nada_mir/src/nada_mir_proto/nillion/nada/types/v1/__init__.py
@@ -88,3 +88,18 @@ class NadaType(betterproto.Message):
     tuple: "Tuple" = betterproto.message_field(11, group="nada_type")
     ntuple: "Ntuple" = betterproto.message_field(12, group="nada_type")
     object: "Object" = betterproto.message_field(13, group="nada_type")
+    ecdsa_public_key: "betterproto_lib_google_protobuf.Empty" = (
+        betterproto.message_field(14, group="nada_type")
+    )
+    eddsa_private_key: "betterproto_lib_google_protobuf.Empty" = (
+        betterproto.message_field(15, group="nada_type")
+    )
+    eddsa_public_key: "betterproto_lib_google_protobuf.Empty" = (
+        betterproto.message_field(16, group="nada_type")
+    )
+    eddsa_message: "betterproto_lib_google_protobuf.Empty" = betterproto.message_field(
+        17, group="nada_type"
+    )
+    eddsa_signature: "betterproto_lib_google_protobuf.Empty" = (
+        betterproto.message_field(18, group="nada_type")
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nada_dsl"
-version = "0.8.1rc1"
+version = "0.8.1rc2"
 description = "Nillion Nada DSL to create Nillion MPC programs."
 requires-python = ">=3.10"
 readme = "README.pyproject.md"

--- a/tests/compile_test.py
+++ b/tests/compile_test.py
@@ -144,12 +144,51 @@ def test_compile_ecdsa_program():
 from nada_dsl import *
 
 def nada_main():
-    party1 = Party(name="Party1")
-    private_key = EcdsaPrivateKey(Input(name="private_key", party=party1))
-    digest = EcdsaDigestMessage(Input(name="digest", party=party1))
+    tecdsa_key_party = Party(name="tecdsa_key_party")
+    tecdsa_digest_message_party = Party(name="tecdsa_digest_message_party")
+    tecdsa_output_party = Party(name="tecdsa_output_party")
 
-    new_int = private_key.ecdsa_sign(digest)
-    return [Output(new_int, "my_output", party1)]
+    key = EcdsaPrivateKey(Input(name="tecdsa_private_key", party=tecdsa_key_party))
+    public_key = key.public_key()
+    digest = EcdsaDigestMessage(
+        Input(name="tecdsa_digest_message", party=tecdsa_digest_message_party)
+    )
+
+    signature = key.ecdsa_sign(digest)
+
+    return [
+        Output(signature, "tecdsa_signature", tecdsa_output_party),
+        Output(digest, "tecdsa_digest_message", tecdsa_output_party),
+        Output(public_key, "tecdsa_public_key", tecdsa_output_party),
+    ]
+"""
+    encoded_program_str = base64.b64encode(bytes(program_str, "utf-8")).decode("utf_8")
+    mir_bytes = compile_string(encoded_program_str).mir
+    assert len(mir_bytes) > 0
+
+
+def test_compile_eddsa_program():
+    program_str = """
+from nada_dsl import *
+
+def nada_main():
+    teddsa_key_party = Party(name="teddsa_key_party")
+    teddsa_message_party = Party(name="teddsa_message_party")
+    teddsa_output_party = Party(name="teddsa_output_party")
+
+    key = EddsaPrivateKey(Input(name="teddsa_private_key", party=teddsa_key_party))
+    public_key = key.public_key()
+    message = EddsaMessage(
+        Input(name="teddsa_message", party=teddsa_message_party)
+    )
+
+    signature = key.eddsa_sign(message)
+
+    return [
+        Output(signature, "teddsa_signature", teddsa_output_party),
+        Output(message, "teddsa_message", teddsa_output_party),
+        Output(public_key, "teddsa_public_key", teddsa_output_party),
+    ]
 """
     encoded_program_str = base64.b64encode(bytes(program_str, "utf-8")).decode("utf_8")
     mir_bytes = compile_string(encoded_program_str).mir


### PR DESCRIPTION
1. Eddsa integration:
1.1 Adding support for `EddsaSignature`, `EddsaPrivateKey` and `EddsaMessage` types and `eddsa_sign` function

2. Allow both ECDSA and EdDSA programs to output the public key of the signature:
2.1 Add `.public_key()` method to both `EcdsaPrivateKey` and `EddsaPrivateKey`
2.2 Add support for `EcdsaPublicKey` and `EddsaPublicKey`

Fixes #
Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nada-dsl/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Backwards compatibility analysis completed (if applicable). "Will this change require recompilation and upload of user programs?"
